### PR TITLE
Applicative and Monad instances for quadrant

### DIFF
--- a/Data/QuadTree/Internal.hs
+++ b/Data/QuadTree/Internal.hs
@@ -78,6 +78,24 @@ instance Functor Quadrant where
                                 (fmap fn c)
                                 (fmap fn d)
 
+
+instance Applicative Quadrant where
+  pure = Leaf
+  Leaf f <*> Leaf x = Leaf $ f x
+  f@Leaf {} <*> Node a b c d =
+    Node (f <*> a) (f <*> b) (f <*> c) (f <*> d)
+  Node fa fb fc fd <*> x@Leaf {} =
+    Node (fa <*> x) (fb <*> x) (fc <*> x) (fd <*> x)
+  Node fa fb fc fd <*> Node a b c d =
+    Node (fa <*> a) (fb <*> b) (fc <*> c) (fd <*> d)
+
+
+instance Monad Quadrant where
+  return = pure
+  Leaf a >>= f = f a
+  Node a b c d >>= f = Node (a >>= f) (b >>= f) (c >>= f) (d >>= f)
+
+
 ---- Quadrant lenses:
 
 -- |Lens for the top left 'Quadrant' of a node.


### PR DESCRIPTION
Exactly what it says on the tin :) We should be able to use these to get the same instances for `QuadTree` assuming we resize both to have the same dimensions before lifting into the `WrappedTree`,  but the dimensional math is escaping me right now.